### PR TITLE
new rest-client version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -109,7 +109,7 @@ dependencies {
     testCompile 'org.mockito:mockito-core:1.9.5'
     testCompile 'junit:junit:4.10'
     compile 'org.codehaus.jackson:jackson-mapper-asl:1.9.13'
-    compile 'com.sequenceiq:cloudbreak-rest-client:0.2.3'
+    compile 'com.sequenceiq:cloudbreak-rest-client:0.2.5'
     compile 'com.github.lalyos:jfiglet:0.0.3'
 
     testCompile 'org.springframework.boot:spring-boot-starter-test:1.0.2.RELEASE'

--- a/src/main/java/com/sequenceiq/cloudbreak/shell/commands/BlueprintCommands.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/shell/commands/BlueprintCommands.java
@@ -94,7 +94,7 @@ public class BlueprintCommands implements CommandMarker {
     @CliCommand(value = "blueprint list", help = "Shows the currently available blueprints")
     public String listBlueprints() {
         try {
-            return renderSingleMap(cloudbreak.getBlueprintsMap(), "ID", "INFO");
+            return renderSingleMap(cloudbreak.getAccountBlueprintsMap(), "ID", "INFO");
         } catch (HttpResponseException ex) {
             return ex.getResponse().getData().toString();
         } catch (Exception ex) {
@@ -152,12 +152,13 @@ public class BlueprintCommands implements CommandMarker {
             @CliOption(key = "description", mandatory = true, help = "Description of the blueprint to download from") String description,
             @CliOption(key = "name", mandatory = true, help = "Name of the blueprint to download from") String name,
             @CliOption(key = "url", mandatory = false, help = "URL of the blueprint to download from") String url,
-            @CliOption(key = "file", mandatory = false, help = "File which contains the blueprint") File file) {
+            @CliOption(key = "file", mandatory = false, help = "File which contains the blueprint") File file,
+            @CliOption(key = "publicInAccount", mandatory = false, help = "flags if the blueprint is public in the account") Boolean publicInAccount) {
         String message;
         try {
             String json = file == null ? readContent(url) : readContent(file);
             if (json != null) {
-                String id = cloudbreak.postBlueprint(name, description, json);
+                String id = cloudbreak.postBlueprint(name, description, json, publicInAccount);
                 context.addBlueprint(id);
                 context.setHint(Hints.CREATE_STACK);
                 message = String.format("Blueprint: '%s' has been added, id: %s", getBlueprintName(json), id);

--- a/src/main/java/com/sequenceiq/cloudbreak/shell/commands/CredentialCommands.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/shell/commands/CredentialCommands.java
@@ -86,7 +86,7 @@ public class CredentialCommands implements CommandMarker {
     @CliCommand(value = "credential list", help = "Shows all of your credentials")
     public String listCredentials() {
         try {
-            return renderSingleMap(cloudbreak.getCredentialsMap(), "ID", "INFO");
+            return renderSingleMap(cloudbreak.getAccountCredentialsMap(), "ID", "INFO");
         } catch (Exception ex) {
             return ex.toString();
         }
@@ -114,8 +114,9 @@ public class CredentialCommands implements CommandMarker {
             @CliOption(key = "description", mandatory = true, help = "Description of the credential") String description,
             @CliOption(key = "name", mandatory = true, help = "Name of the credential") String name,
             @CliOption(key = "roleArn", mandatory = true, help = "roleArn of the credential") String roleArn,
-            @CliOption(key = "sshKeyPath", mandatory = false, help = "sshKeyPath of the template") String sshKeyPath,
-            @CliOption(key = "sshKeyUrl", mandatory = false, help = "sshKeyUrl of the template") String sshKeyUrl
+            @CliOption(key = "sshKeyPath", mandatory = false, help = "path of a public SSH key file") String sshKeyPath,
+            @CliOption(key = "sshKeyUrl", mandatory = false, help = "URL of a public SSH key file") String sshKeyUrl,
+            @CliOption(key = "publicInAccount", mandatory = false, help = "flags if the credential is public in the account") Boolean publicInAccount
     ) {
         if ((sshKeyPath == null || sshKeyPath.isEmpty()) && (sshKeyUrl == null || sshKeyUrl.isEmpty())) {
             return "An SSH public key must be specified either with --sshKeyPath or --sshKeyUrl";
@@ -135,7 +136,7 @@ public class CredentialCommands implements CommandMarker {
             }
         }
         try {
-            String id = cloudbreak.postEc2Credential(name, description, roleArn, sshKey);
+            String id = cloudbreak.postEc2Credential(name, description, roleArn, sshKey, publicInAccount);
             context.setCredential(id);
             context.setHint(Hints.CREATE_TEMPLATE);
             return "Credential created, id: " + id;
@@ -172,7 +173,8 @@ public class CredentialCommands implements CommandMarker {
             @CliOption(key = "subscriptionId", mandatory = true, help = "subscriptionId of the credential") String subscriptionId,
             @CliOption(key = "jksPassword", mandatory = true, help = "jksPassword of the credential") String jksPassword,
             @CliOption(key = "sshKeyPath", mandatory = false, help = "sshKeyPath of the template") String sshKeyPath,
-            @CliOption(key = "sshKeyUrl", mandatory = false, help = "sshKeyUrl of the template") String sshKeyUrl
+            @CliOption(key = "sshKeyUrl", mandatory = false, help = "sshKeyUrl of the template") String sshKeyUrl,
+            @CliOption(key = "publicInAccount", mandatory = false, help = "flags if the credential is public in the account") Boolean publicInAccount
     ) {
         if ((sshKeyPath == null || sshKeyPath.isEmpty()) && (sshKeyUrl == null || sshKeyUrl.isEmpty())) {
             return "SshKey cannot be null if password null";
@@ -192,7 +194,7 @@ public class CredentialCommands implements CommandMarker {
             }
         }
         try {
-            String id = cloudbreak.postAzureCredential(name, description, subscriptionId, jksPassword, sshKey);
+            String id = cloudbreak.postAzureCredential(name, description, subscriptionId, jksPassword, sshKey, publicInAccount);
             context.setCredential(id);
             context.setHint(Hints.CREATE_TEMPLATE);
             return "Credential created, id: " + id;
@@ -206,7 +208,7 @@ public class CredentialCommands implements CommandMarker {
     @CliAvailabilityIndicator(value = "credential certificate")
     public boolean isCredentialCertificateCommandAvailable() {
         try {
-            List<Map> credentials = cloudbreak.getCredentials();
+            List<Map> credentials = cloudbreak.getAccountCredentials();
             int count = 0;
             maps = new ArrayList<>();
             for (Map map : credentials) {

--- a/src/main/java/com/sequenceiq/cloudbreak/shell/commands/StackCommands.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/shell/commands/StackCommands.java
@@ -53,9 +53,10 @@ public class StackCommands implements CommandMarker {
     @CliCommand(value = "stack create", help = "Create a new stack based on a template")
     public String createStack(
             @CliOption(key = "nodeCount", mandatory = true, help = "Number of nodes to create") String count,
-            @CliOption(key = "name", mandatory = true, help = "Name of the stack") String name) {
+            @CliOption(key = "name", mandatory = true, help = "Name of the stack") String name,
+            @CliOption(key = "publicInAccount", mandatory = false, help = "flags if the stack is public in the account") Boolean publicInAccount) {
         try {
-            String id = cloudbreak.postStack(name, count, context.getCredentialId(), context.getTemplateId());
+            String id = cloudbreak.postStack(name, count, context.getCredentialId(), context.getTemplateId(), publicInAccount);
             context.addStack(id, name);
             context.setHint(Hints.CREATE_CLUSTER);
             return "Stack created, id: " + id;
@@ -103,7 +104,7 @@ public class StackCommands implements CommandMarker {
     @CliCommand(value = "stack list", help = "Shows all of your stack")
     public String listStacks() {
         try {
-            return renderSingleMap(cloudbreak.getStacksMap(), "ID", "INFO");
+            return renderSingleMap(cloudbreak.getAccountStacksMap(), "ID", "INFO");
         } catch (HttpResponseException ex) {
             return ex.getResponse().getData().toString();
         } catch (Exception ex) {

--- a/src/main/java/com/sequenceiq/cloudbreak/shell/commands/TemplateCommands.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/shell/commands/TemplateCommands.java
@@ -72,7 +72,7 @@ public class TemplateCommands implements CommandMarker {
     @CliCommand(value = "template list", help = "Shows the currently available cloud templates")
     public String listTemplates() {
         try {
-            Map<String, String> templatesMap = cloudbreak.getTemplatesMap();
+            Map<String, String> templatesMap = cloudbreak.getAccountTemplatesMap();
             return renderSingleMap(templatesMap, "ID", "INFO");
         } catch (HttpResponseException ex) {
             return ex.getResponse().getData().toString();
@@ -110,7 +110,8 @@ public class TemplateCommands implements CommandMarker {
             @CliOption(key = "volumeSize", mandatory = true, help = "volumeSize(GB) of the template") Integer volumeSize,
             @CliOption(key = "volumeType", mandatory = false, help = "volumeType of the template", specifiedDefaultValue = "Gp2") VolumeType volumeType,
             @CliOption(key = "spotPrice", mandatory = false, help = "spotPrice of the template") Double spotPrice,
-            @CliOption(key = "sshLocation", mandatory = false, specifiedDefaultValue = "0.0.0.0/0", help = "sshLocation of the template") String sshLocation
+            @CliOption(key = "sshLocation", mandatory = false, specifiedDefaultValue = "0.0.0.0/0", help = "sshLocation of the template") String sshLocation,
+            @CliOption(key = "publicInAccount", mandatory = false, help = "flags if the template is public in the account") Boolean publicInAccount
     ) {
         try {
             if (volumeCount < VOLUME_COUNT_MIN || volumeCount > VOLUME_COUNT_MAX) {
@@ -132,7 +133,8 @@ public class TemplateCommands implements CommandMarker {
                         instanceType.toString(),
                         volumeCount.toString(),
                         volumeSize.toString(),
-                        volumeType.name()
+                        volumeType.name(),
+                        publicInAccount
                 );
             } else {
                 id = cloudbreak.postSpotEc2Template(name,
@@ -144,7 +146,8 @@ public class TemplateCommands implements CommandMarker {
                         volumeCount.toString(),
                         volumeSize.toString(),
                         volumeType.name(),
-                        spotPrice.toString()
+                        spotPrice.toString(),
+                        publicInAccount
                 );
             }
             context.addTemplate(id);
@@ -166,7 +169,8 @@ public class TemplateCommands implements CommandMarker {
             @CliOption(key = "vmType", mandatory = true, help = "type of the VM") AzureVmType vmType,
             @CliOption(key = "volumeCount", mandatory = true, help = "volumeCount of the template") Integer volumeCount,
             @CliOption(key = "volumeSize", mandatory = true, help = "volumeSize(GB) of the template") Integer volumeSize,
-            @CliOption(key = "imageName", mandatory = false, help = "instance name of the template: AMBARI_DOCKER_V1") AzureInstanceName imageName
+            @CliOption(key = "imageName", mandatory = false, help = "instance name of the template: AMBARI_DOCKER_V1") AzureInstanceName imageName,
+            @CliOption(key = "publicInAccount", mandatory = false, help = "flags if the template is public in the account") Boolean publicInAccount
     ) {
         if (volumeCount < VOLUME_COUNT_MIN || volumeCount > VOLUME_COUNT_MAX) {
             return "volumeCount has to be between 1 and 8.";
@@ -184,7 +188,8 @@ public class TemplateCommands implements CommandMarker {
                     imageName.name(),
                     vmType.name(),
                     volumeCount.toString(),
-                    volumeSize.toString()
+                    volumeSize.toString(),
+                    publicInAccount
             );
             context.addTemplate(id);
             context.setHint(Hints.ADD_BLUEPRINT);


### PR DESCRIPTION
- shell lists every visible resources in account (templates, blueprints)
- when creating a new resource it can be specified if it will be available for the account (default is private)
