### PR TITLE
CLOUD-434 Add version info to MANIFEST to fix version command

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,10 @@ allprojects {
 
 jar {
     baseName = 'cloudbreak-shell'
+    manifest {
+        attributes("Implementation-Title": "Gradle",
+                   "Implementation-Version": version)
+    }
 }
 
 configurations {


### PR DESCRIPTION
`version` command is broken because the MANIFEST file is missing the implementation version property.
This is the fix for gradle build.