### PR TITLE
CLOUD-481 usage displayed on --help or -h

### DIFF
--- a/src/main/java/com/sequenceiq/cloudbreak/shell/CloudbreakShell.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/shell/CloudbreakShell.java
@@ -69,7 +69,7 @@ public class CloudbreakShell implements CommandLineRunner, ShellStatusListener {
     }
 
     public static void main(String[] args) throws IOException {
-        if (args.length == 0) {
+        if (args.length == 1 && ("--help".equals(args[0]) || "-h".equals(args[0]))) {
             System.out.println(
                     "\nCloudbreak Shell: Interactive command line tool for managing Cloudbreak.\n\n"
                             + "Usage:\n"


### PR DESCRIPTION
When the [sequenceiq/cb-shell](https://github.com/sequenceiq/docker-cb-shell) image is used it should be possible to start it with all paramateres speciefied as ENV variables. 

Right now if no `--some.option=value` is used then the usage/help is displayed, which leads to [hacky start script](https://github.com/sequenceiq/docker-cb-shell/blob/6ae138c9d7ba46f360f8e382b5c96526386b9e95/start#L17-L19)

@doktoric please check it